### PR TITLE
Fix link types

### DIFF
--- a/packages/Accordion/CHANGELOG.md
+++ b/packages/Accordion/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.4.6](https://github.com/mindbody/design-system/compare/@mbkit/accordion@1.4.5...@mbkit/accordion@1.4.6) (2020-04-01)
+
+**Note:** Version bump only for package @mbkit/accordion
+
+
+
+
+
 ## [1.4.5](https://github.com/mindbody/design-system/compare/@mbkit/accordion@1.4.4...@mbkit/accordion@1.4.5) (2020-03-26)
 
 **Note:** Version bump only for package @mbkit/accordion

--- a/packages/Accordion/package.json
+++ b/packages/Accordion/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mbkit/accordion",
-    "version": "1.4.5",
+    "version": "1.4.6",
     "source": "src/index.tsx",
     "main": "dist/cjs/Accordion.js",
     "module": "dist/esm/Accordion.js",
@@ -24,7 +24,7 @@
     },
     "dependencies": {
         "@mbkit/icon": "1.2.5",
-        "@mbkit/theme": "^2.0.1",
+        "@mbkit/theme": "^2.0.2",
         "classnames": "^2.2.6",
         "nanoid": "^2.1.7"
     }

--- a/packages/ActionBanner/CHANGELOG.md
+++ b/packages/ActionBanner/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.6](https://github.com/mindbody/design-system/compare/@mbkit/action-banner@1.2.5...@mbkit/action-banner@1.2.6) (2020-04-01)
+
+**Note:** Version bump only for package @mbkit/action-banner
+
+
+
+
+
 ## [1.2.5](https://github.com/mindbody/design-system/compare/@mbkit/action-banner@1.2.4...@mbkit/action-banner@1.2.5) (2020-03-26)
 
 **Note:** Version bump only for package @mbkit/action-banner

--- a/packages/ActionBanner/package.json
+++ b/packages/ActionBanner/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mbkit/action-banner",
-    "version": "1.2.5",
+    "version": "1.2.6",
     "source": "src/index.tsx",
     "main": "dist/cjs/ActionBanner.js",
     "module": "dist/esm/ActionBanner.js",
@@ -22,7 +22,7 @@
         "react": "^16.9.0"
     },
     "dependencies": {
-        "@mbkit/theme": "^2.0.1",
+        "@mbkit/theme": "^2.0.2",
         "@reach/alert": "^0.6.2",
         "@types/reach__alert": "^0.1.1",
         "classnames": "^2.2.6"

--- a/packages/Banner/CHANGELOG.md
+++ b/packages/Banner/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.3.6](https://github.com/mindbody/design-system/compare/@mbkit/banner@1.3.5...@mbkit/banner@1.3.6) (2020-04-01)
+
+**Note:** Version bump only for package @mbkit/banner
+
+
+
+
+
 ## [1.3.5](https://github.com/mindbody/design-system/compare/@mbkit/banner@1.3.4...@mbkit/banner@1.3.5) (2020-03-26)
 
 **Note:** Version bump only for package @mbkit/banner

--- a/packages/Banner/package.json
+++ b/packages/Banner/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mbkit/banner",
-    "version": "1.3.5",
+    "version": "1.3.6",
     "source": "src/index.tsx",
     "main": "dist/cjs/Banner.js",
     "module": "dist/esm/Banner.js",
@@ -22,7 +22,7 @@
         "react": "^16.9.0"
     },
     "dependencies": {
-        "@mbkit/theme": "^2.0.1",
+        "@mbkit/theme": "^2.0.2",
         "classnames": "^2.2.6"
     }
 }

--- a/packages/Button/CHANGELOG.md
+++ b/packages/Button/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.3.6](https://github.com/mindbody/design-system/compare/@mbkit/button@1.3.5...@mbkit/button@1.3.6) (2020-04-01)
+
+**Note:** Version bump only for package @mbkit/button
+
+
+
+
+
 ## [1.3.5](https://github.com/mindbody/design-system/compare/@mbkit/button@1.3.4...@mbkit/button@1.3.5) (2020-03-26)
 
 **Note:** Version bump only for package @mbkit/button

--- a/packages/Button/package.json
+++ b/packages/Button/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mbkit/button",
-    "version": "1.3.5",
+    "version": "1.3.6",
     "source": "src/index.tsx",
     "main": "dist/cjs/Button.js",
     "module": "dist/esm/Button.js",
@@ -22,7 +22,7 @@
         "react": "^16.9.0"
     },
     "dependencies": {
-        "@mbkit/theme": "^2.0.1",
+        "@mbkit/theme": "^2.0.2",
         "classnames": "^2.2.6"
     }
 }

--- a/packages/Calendar/CHANGELOG.md
+++ b/packages/Calendar/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.3.6](https://github.com/mindbody/design-system/compare/@mbkit/calendar@1.3.5...@mbkit/calendar@1.3.6) (2020-04-01)
+
+**Note:** Version bump only for package @mbkit/calendar
+
+
+
+
+
 ## [1.3.5](https://github.com/mindbody/design-system/compare/@mbkit/calendar@1.3.4...@mbkit/calendar@1.3.5) (2020-03-26)
 
 **Note:** Version bump only for package @mbkit/calendar

--- a/packages/Calendar/package.json
+++ b/packages/Calendar/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mbkit/calendar",
-    "version": "1.3.5",
+    "version": "1.3.6",
     "source": "src/index.tsx",
     "main": "dist/cjs/Calendar.js",
     "module": "dist/esm/Calendar.js",
@@ -22,7 +22,7 @@
         "react": "^16.9.0"
     },
     "dependencies": {
-        "@mbkit/theme": "^2.0.1",
+        "@mbkit/theme": "^2.0.2",
         "classnames": "^2.2.6",
         "react-calendar": "^2.19.2"
     }

--- a/packages/Card/CHANGELOG.md
+++ b/packages/Card/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.3.6](https://github.com/mindbody/design-system/compare/@mbkit/card@1.3.5...@mbkit/card@1.3.6) (2020-04-01)
+
+**Note:** Version bump only for package @mbkit/card
+
+
+
+
+
 ## [1.3.5](https://github.com/mindbody/design-system/compare/@mbkit/card@1.3.4...@mbkit/card@1.3.5) (2020-03-26)
 
 **Note:** Version bump only for package @mbkit/card

--- a/packages/Card/package.json
+++ b/packages/Card/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mbkit/card",
-    "version": "1.3.5",
+    "version": "1.3.6",
     "source": "src/index.tsx",
     "main": "dist/cjs/Card.js",
     "module": "dist/esm/Card.js",
@@ -22,7 +22,7 @@
         "react": "^16.9.0"
     },
     "dependencies": {
-        "@mbkit/theme": "^2.0.1",
+        "@mbkit/theme": "^2.0.2",
         "classnames": "^2.2.6"
     }
 }

--- a/packages/Checkbox/CHANGELOG.md
+++ b/packages/Checkbox/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.3.6](https://github.com/mindbody/design-system/compare/@mbkit/checkbox@1.3.5...@mbkit/checkbox@1.3.6) (2020-04-01)
+
+**Note:** Version bump only for package @mbkit/checkbox
+
+
+
+
+
 ## [1.3.5](https://github.com/mindbody/design-system/compare/@mbkit/checkbox@1.3.4...@mbkit/checkbox@1.3.5) (2020-03-26)
 
 

--- a/packages/Checkbox/package.json
+++ b/packages/Checkbox/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mbkit/checkbox",
-    "version": "1.3.5",
+    "version": "1.3.6",
     "source": "src/index.tsx",
     "main": "dist/cjs/Checkbox.js",
     "module": "dist/esm/Checkbox.js",
@@ -22,7 +22,7 @@
         "react": "^16.9.0"
     },
     "dependencies": {
-        "@mbkit/theme": "^2.0.1",
+        "@mbkit/theme": "^2.0.2",
         "classnames": "^2.2.6"
     }
 }

--- a/packages/Dialog/CHANGELOG.md
+++ b/packages/Dialog/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.3.6](https://github.com/mindbody/design-system/compare/@mbkit/dialog@1.3.5...@mbkit/dialog@1.3.6) (2020-04-01)
+
+**Note:** Version bump only for package @mbkit/dialog
+
+
+
+
+
 ## [1.3.5](https://github.com/mindbody/design-system/compare/@mbkit/dialog@1.3.4...@mbkit/dialog@1.3.5) (2020-03-26)
 
 **Note:** Version bump only for package @mbkit/dialog

--- a/packages/Dialog/package.json
+++ b/packages/Dialog/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mbkit/dialog",
-    "version": "1.3.5",
+    "version": "1.3.6",
     "source": "src/index.tsx",
     "main": "dist/cjs/Dialog.js",
     "module": "dist/esm/Dialog.js",
@@ -23,7 +23,7 @@
         "react": "^16.9.0"
     },
     "dependencies": {
-        "@mbkit/theme": "^2.0.1",
+        "@mbkit/theme": "^2.0.2",
         "@reach/alert-dialog": "^0.6.3",
         "@reach/dialog": "^0.6.4",
         "classnames": "^2.2.6",

--- a/packages/ErrorMessage/CHANGELOG.md
+++ b/packages/ErrorMessage/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.3.6](https://github.com/mindbody/design-system/compare/@mbkit/error-message@1.3.5...@mbkit/error-message@1.3.6) (2020-04-01)
+
+**Note:** Version bump only for package @mbkit/error-message
+
+
+
+
+
 ## [1.3.5](https://github.com/mindbody/design-system/compare/@mbkit/error-message@1.3.4...@mbkit/error-message@1.3.5) (2020-03-26)
 
 **Note:** Version bump only for package @mbkit/error-message

--- a/packages/ErrorMessage/package.json
+++ b/packages/ErrorMessage/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mbkit/error-message",
-    "version": "1.3.5",
+    "version": "1.3.6",
     "source": "src/index.tsx",
     "main": "dist/cjs/ErrorMessage.js",
     "module": "dist/esm/ErrorMessage.js",
@@ -22,7 +22,7 @@
         "react": "^16.9.0"
     },
     "dependencies": {
-        "@mbkit/theme": "^2.0.1",
+        "@mbkit/theme": "^2.0.2",
         "@reach/alert": "^0.5.3",
         "classnames": "^2.2.6"
     }

--- a/packages/FileUploader/CHANGELOG.md
+++ b/packages/FileUploader/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.3.6](https://github.com/mindbody/design-system/compare/@mbkit/file-uploader@1.3.5...@mbkit/file-uploader@1.3.6) (2020-04-01)
+
+**Note:** Version bump only for package @mbkit/file-uploader
+
+
+
+
+
 ## [1.3.5](https://github.com/mindbody/design-system/compare/@mbkit/file-uploader@1.3.4...@mbkit/file-uploader@1.3.5) (2020-03-26)
 
 **Note:** Version bump only for package @mbkit/file-uploader

--- a/packages/FileUploader/package.json
+++ b/packages/FileUploader/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mbkit/file-uploader",
-    "version": "1.3.5",
+    "version": "1.3.6",
     "source": "src/index.tsx",
     "main": "dist/cjs/FileUploader.js",
     "module": "dist/esm/FileUploader.js",
@@ -22,7 +22,7 @@
         "react": "^16.9.0"
     },
     "dependencies": {
-        "@mbkit/theme": "^2.0.1",
+        "@mbkit/theme": "^2.0.2",
         "classnames": "^2.2.6"
     }
 }

--- a/packages/Icon/CHANGELOG.md
+++ b/packages/Icon/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.3.6](https://github.com/mindbody/design-system/compare/@mbkit/icon@1.3.5...@mbkit/icon@1.3.6) (2020-04-01)
+
+**Note:** Version bump only for package @mbkit/icon
+
+
+
+
+
 ## [1.3.5](https://github.com/mindbody/design-system/compare/@mbkit/icon@1.3.4...@mbkit/icon@1.3.5) (2020-03-26)
 
 **Note:** Version bump only for package @mbkit/icon

--- a/packages/Icon/package.json
+++ b/packages/Icon/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mbkit/icon",
-    "version": "1.3.5",
+    "version": "1.3.6",
     "source": "src/index.tsx",
     "main": "dist/cjs/Icon.js",
     "module": "dist/esm/Icon.js",
@@ -23,7 +23,7 @@
         "react": "^16.9.0"
     },
     "dependencies": {
-        "@mbkit/theme": "^2.0.1",
+        "@mbkit/theme": "^2.0.2",
         "classnames": "^2.2.6",
         "nanoid": "^2.1.2"
     }

--- a/packages/Input/CHANGELOG.md
+++ b/packages/Input/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.3.6](https://github.com/mindbody/design-system/compare/@mbkit/input@1.3.5...@mbkit/input@1.3.6) (2020-04-01)
+
+**Note:** Version bump only for package @mbkit/input
+
+
+
+
+
 ## [1.3.5](https://github.com/mindbody/design-system/compare/@mbkit/input@1.3.4...@mbkit/input@1.3.5) (2020-03-26)
 
 **Note:** Version bump only for package @mbkit/input

--- a/packages/Input/package.json
+++ b/packages/Input/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mbkit/input",
-    "version": "1.3.5",
+    "version": "1.3.6",
     "source": "src/index.tsx",
     "main": "dist/cjs/Input.js",
     "module": "dist/esm/Input.js",
@@ -22,7 +22,7 @@
         "react": "^16.9.0"
     },
     "dependencies": {
-        "@mbkit/theme": "^2.0.1",
+        "@mbkit/theme": "^2.0.2",
         "classnames": "^2.2.6"
     }
 }

--- a/packages/Label/CHANGELOG.md
+++ b/packages/Label/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.3.6](https://github.com/mindbody/design-system/compare/@mbkit/label@1.3.5...@mbkit/label@1.3.6) (2020-04-01)
+
+**Note:** Version bump only for package @mbkit/label
+
+
+
+
+
 ## [1.3.5](https://github.com/mindbody/design-system/compare/@mbkit/label@1.3.4...@mbkit/label@1.3.5) (2020-03-26)
 
 **Note:** Version bump only for package @mbkit/label

--- a/packages/Label/package.json
+++ b/packages/Label/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mbkit/label",
-    "version": "1.3.5",
+    "version": "1.3.6",
     "source": "src/index.tsx",
     "main": "dist/cjs/Label.js",
     "module": "dist/esm/Label.js",
@@ -22,7 +22,7 @@
         "react": "^16.9.0"
     },
     "dependencies": {
-        "@mbkit/theme": "^2.0.1",
+        "@mbkit/theme": "^2.0.2",
         "classnames": "^2.2.6"
     }
 }

--- a/packages/Modal/CHANGELOG.md
+++ b/packages/Modal/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.3.6](https://github.com/mindbody/design-system/compare/@mbkit/modal@1.3.5...@mbkit/modal@1.3.6) (2020-04-01)
+
+**Note:** Version bump only for package @mbkit/modal
+
+
+
+
+
 ## [1.3.5](https://github.com/mindbody/design-system/compare/@mbkit/modal@1.3.4...@mbkit/modal@1.3.5) (2020-03-26)
 
 **Note:** Version bump only for package @mbkit/modal

--- a/packages/Modal/package.json
+++ b/packages/Modal/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mbkit/modal",
-    "version": "1.3.5",
+    "version": "1.3.6",
     "source": "src/index.tsx",
     "main": "dist/cjs/Modal.js",
     "module": "dist/esm/Modal.js",
@@ -23,7 +23,7 @@
         "react": "^16.9.0"
     },
     "dependencies": {
-        "@mbkit/theme": "^2.0.1",
+        "@mbkit/theme": "^2.0.2",
         "@reach/dialog": "^0.5.4",
         "classnames": "^2.2.6",
         "react-transition-group": "^4.3.0"

--- a/packages/Radio/CHANGELOG.md
+++ b/packages/Radio/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.3.6](https://github.com/mindbody/design-system/compare/@mbkit/radio@1.3.5...@mbkit/radio@1.3.6) (2020-04-01)
+
+**Note:** Version bump only for package @mbkit/radio
+
+
+
+
+
 ## [1.3.5](https://github.com/mindbody/design-system/compare/@mbkit/radio@1.3.4...@mbkit/radio@1.3.5) (2020-03-26)
 
 **Note:** Version bump only for package @mbkit/radio

--- a/packages/Radio/package.json
+++ b/packages/Radio/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mbkit/radio",
-    "version": "1.3.5",
+    "version": "1.3.6",
     "source": "src/index.tsx",
     "main": "dist/cjs/Radio.js",
     "module": "dist/esm/Radio.js",
@@ -22,7 +22,7 @@
         "react": "^16.9.0"
     },
     "dependencies": {
-        "@mbkit/theme": "^2.0.1",
+        "@mbkit/theme": "^2.0.2",
         "classnames": "^2.2.6"
     }
 }

--- a/packages/Select/CHANGELOG.md
+++ b/packages/Select/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.3.6](https://github.com/mindbody/design-system/compare/@mbkit/select@1.3.5...@mbkit/select@1.3.6) (2020-04-01)
+
+**Note:** Version bump only for package @mbkit/select
+
+
+
+
+
 ## [1.3.5](https://github.com/mindbody/design-system/compare/@mbkit/select@1.3.4...@mbkit/select@1.3.5) (2020-03-26)
 
 **Note:** Version bump only for package @mbkit/select

--- a/packages/Select/package.json
+++ b/packages/Select/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mbkit/select",
-    "version": "1.3.5",
+    "version": "1.3.6",
     "source": "src/index.tsx",
     "main": "dist/cjs/Select.js",
     "module": "dist/esm/Select.js",
@@ -23,8 +23,8 @@
         "react": "^16.9.0"
     },
     "dependencies": {
-        "@mbkit/checkbox": "^1.3.5",
-        "@mbkit/theme": "^2.0.1",
+        "@mbkit/checkbox": "^1.3.6",
+        "@mbkit/theme": "^2.0.2",
         "classnames": "^2.2.6",
         "nanoid": "^2.1.8"
     }

--- a/packages/Textarea/CHANGELOG.md
+++ b/packages/Textarea/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.3.6](https://github.com/mindbody/design-system/compare/@mbkit/textarea@1.3.5...@mbkit/textarea@1.3.6) (2020-04-01)
+
+**Note:** Version bump only for package @mbkit/textarea
+
+
+
+
+
 ## [1.3.5](https://github.com/mindbody/design-system/compare/@mbkit/textarea@1.3.4...@mbkit/textarea@1.3.5) (2020-03-26)
 
 **Note:** Version bump only for package @mbkit/textarea

--- a/packages/Textarea/package.json
+++ b/packages/Textarea/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mbkit/textarea",
-    "version": "1.3.5",
+    "version": "1.3.6",
     "source": "src/index.tsx",
     "main": "dist/cjs/Textarea.js",
     "module": "dist/esm/Textarea.js",
@@ -22,7 +22,7 @@
         "react": "^16.9.0"
     },
     "dependencies": {
-        "@mbkit/theme": "^2.0.1",
+        "@mbkit/theme": "^2.0.2",
         "classnames": "^2.2.6"
     }
 }

--- a/packages/Theme/CHANGELOG.md
+++ b/packages/Theme/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.2](https://github.com/mindbody/design-system/compare/@mbkit/theme@2.0.1...@mbkit/theme@2.0.2) (2020-04-01)
+
+**Note:** Version bump only for package @mbkit/theme
+
+
+
+
+
 ## [2.0.1](https://github.com/mindbody/design-system/compare/@mbkit/theme@2.0.0...@mbkit/theme@2.0.1) (2020-03-26)
 
 **Note:** Version bump only for package @mbkit/theme

--- a/packages/Theme/package.json
+++ b/packages/Theme/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mbkit/theme",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "source": "src/index.tsx",
     "main": "dist/cjs/Theme.js",
     "module": "dist/esm/Theme.js",

--- a/packages/Tipsy/CHANGELOG.md
+++ b/packages/Tipsy/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.3.6](https://github.com/mindbody/design-system/compare/@mbkit/tipsy@1.3.5...@mbkit/tipsy@1.3.6) (2020-04-01)
+
+**Note:** Version bump only for package @mbkit/tipsy
+
+
+
+
+
 ## [1.3.5](https://github.com/mindbody/design-system/compare/@mbkit/tipsy@1.3.4...@mbkit/tipsy@1.3.5) (2020-03-26)
 
 **Note:** Version bump only for package @mbkit/tipsy

--- a/packages/Tipsy/package.json
+++ b/packages/Tipsy/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mbkit/tipsy",
-    "version": "1.3.5",
+    "version": "1.3.6",
     "source": "src/index.tsx",
     "main": "dist/cjs/Tipsy.js",
     "module": "dist/esm/Tipsy.js",
@@ -25,7 +25,7 @@
         "react": "^16.9.0"
     },
     "dependencies": {
-        "@mbkit/theme": "^2.0.1",
+        "@mbkit/theme": "^2.0.2",
         "@reach/portal": "^0.4.0",
         "@reach/tooltip": "^0.4.0",
         "classnames": "^2.2.6"

--- a/packages/Toaster/CHANGELOG.md
+++ b/packages/Toaster/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.3.6](https://github.com/mindbody/design-system/compare/@mbkit/toaster@1.3.5...@mbkit/toaster@1.3.6) (2020-04-01)
+
+**Note:** Version bump only for package @mbkit/toaster
+
+
+
+
+
 ## [1.3.5](https://github.com/mindbody/design-system/compare/@mbkit/toaster@1.3.4...@mbkit/toaster@1.3.5) (2020-03-26)
 
 **Note:** Version bump only for package @mbkit/toaster

--- a/packages/Toaster/package.json
+++ b/packages/Toaster/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mbkit/toaster",
-    "version": "1.3.5",
+    "version": "1.3.6",
     "source": "src/index.tsx",
     "main": "dist/cjs/Toaster.js",
     "module": "dist/esm/Toaster.js",
@@ -22,7 +22,7 @@
         "react": "^16.9.0"
     },
     "dependencies": {
-        "@mbkit/theme": "^2.0.1",
+        "@mbkit/theme": "^2.0.2",
         "@reach/alert": "^0.6.2",
         "@reach/portal": "^0.6.2",
         "classnames": "^2.2.6"

--- a/packages/Toggle/CHANGELOG.md
+++ b/packages/Toggle/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.3.6](https://github.com/mindbody/design-system/compare/@mbkit/toggle@1.3.5...@mbkit/toggle@1.3.6) (2020-04-01)
+
+**Note:** Version bump only for package @mbkit/toggle
+
+
+
+
+
 ## [1.3.5](https://github.com/mindbody/design-system/compare/@mbkit/toggle@1.3.4...@mbkit/toggle@1.3.5) (2020-03-26)
 
 **Note:** Version bump only for package @mbkit/toggle

--- a/packages/Toggle/package.json
+++ b/packages/Toggle/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mbkit/toggle",
-    "version": "1.3.5",
+    "version": "1.3.6",
     "source": "src/index.tsx",
     "main": "dist/cjs/Toggle.js",
     "module": "dist/esm/Toggle.js",
@@ -22,7 +22,7 @@
         "react": "^16.9.0"
     },
     "dependencies": {
-        "@mbkit/theme": "^2.0.1",
+        "@mbkit/theme": "^2.0.2",
         "classnames": "^2.2.6"
     }
 }

--- a/packages/Typography/CHANGELOG.md
+++ b/packages/Typography/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.3.6](https://github.com/mindbody/design-system/compare/@mbkit/typography@1.3.5...@mbkit/typography@1.3.6) (2020-04-01)
+
+
+### Bug Fixes
+
+* **typography:** updated types for link element ([4bdbbf3](https://github.com/mindbody/design-system/commit/4bdbbf3e4c83e3c4d4c26dedea02384d780d9948))
+
+
+
+
+
 ## [1.3.5](https://github.com/mindbody/design-system/compare/@mbkit/typography@1.3.4...@mbkit/typography@1.3.5) (2020-03-26)
 
 **Note:** Version bump only for package @mbkit/typography

--- a/packages/Typography/package.json
+++ b/packages/Typography/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mbkit/typography",
-    "version": "1.3.5",
+    "version": "1.3.6",
     "source": "src/index.tsx",
     "main": "dist/cjs/Typography.js",
     "module": "dist/esm/Typography.js",
@@ -22,7 +22,7 @@
         "react": "^16.9.0"
     },
     "dependencies": {
-        "@mbkit/theme": "^2.0.1",
+        "@mbkit/theme": "^2.0.2",
         "classnames": "^2.2.6"
     }
 }

--- a/packages/Typography/src/Link.tsx
+++ b/packages/Typography/src/Link.tsx
@@ -1,8 +1,8 @@
-import React, { HTMLAttributes, RefObject, RefAttributes } from 'react';
+import React, { AllHTMLAttributes, RefObject, RefAttributes } from 'react';
 import classnames from 'classnames';
 import styles from './Typography.scss';
 
-export type LinkProps = HTMLAttributes<HTMLElement> &
+export type LinkProps = AllHTMLAttributes<HTMLElement> &
     RefAttributes<HTMLElement> & {
         /** This will be the actual rendered element */
         as?: React.ReactNode;
@@ -19,3 +19,4 @@ export const Link: React.FC<LinkProps> = React.forwardRef((props: LinkProps, ref
 
     return <Component {...rest} className={classNames} ref={ref} />;
 });
+Link.displayName = 'Link';

--- a/packages/Typography/src/__tests__/Link.test.tsx
+++ b/packages/Typography/src/__tests__/Link.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Link } from '../Link';
+
+describe('Link element', () => {
+    it('should render an anchor without crashing', () => {
+        const { getByText } = render(<Link href="/test">Test</Link>);
+        expect(getByText('Test')).toBeTruthy();
+    });
+});

--- a/packages/docs/CHANGELOG.md
+++ b/packages/docs/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.7.4](https://github.com/gatsbyjs/gatsby-starter-default/compare/@mbkit/docs@0.7.3...@mbkit/docs@0.7.4) (2020-04-01)
+
+**Note:** Version bump only for package @mbkit/docs
+
+
+
+
+
 ## [0.7.3](https://github.com/gatsbyjs/gatsby-starter-default/compare/@mbkit/docs@0.7.2...@mbkit/docs@0.7.3) (2020-03-26)
 
 **Note:** Version bump only for package @mbkit/docs

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -2,7 +2,7 @@
   "name": "@mbkit/docs",
   "private": true,
   "description": "Design system documentation for MINDBODY",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "author": "Cameron Zaas <cameron.zaas@mindbodyonline.com>",
   "scripts": {
     "clone:env:file": "yarn copyfiles ../../.env ./docs/.env",
@@ -15,8 +15,8 @@
   "dependencies": {
     "@contentful/gatsby-transformer-contentful-richtext": "^13.1.0",
     "@contentful/rich-text-react-renderer": "^13.4.0",
-    "@mbkit/theme": "^2.0.1",
-    "@mbkit/toggle": "^1.3.5",
+    "@mbkit/theme": "^2.0.2",
+    "@mbkit/toggle": "^1.3.6",
     "@mdx-js/react": "^1.4.0",
     "@reach/component-component": "^0.6.2",
     "@reach/skip-nav": "^0.1.3",


### PR DESCRIPTION
Using `AllHTMLAttributes` to fix type error when adding `href` property

addresses #84 