### PR TITLE
Fix commands in Package.json files to be compatible for Windows OS

### DIFF
--- a/packages/Accordion/package.json
+++ b/packages/Accordion/package.json
@@ -9,7 +9,7 @@
         "access": "public"
     },
     "scripts": {
-        "build": "../../shared/build-tools/build-package.js",
+        "build": "../../node_modules/.bin/rollup -c ../../shared/build-tools/rollup.config.js  ",
         "dev": "../../shared/build-tools/dev-package.js"
     },
     "license": "MIT",

--- a/packages/ActionBanner/package.json
+++ b/packages/ActionBanner/package.json
@@ -9,7 +9,7 @@
         "access": "public"
     },
     "scripts": {
-        "build": "../../shared/build-tools/build-package.js",
+        "build": "../../node_modules/.bin/rollup -c ../../shared/build-tools/rollup.config.js  ",
         "dev": "../../shared/build-tools/dev-package.js"
     },
     "license": "MIT",

--- a/packages/Banner/package.json
+++ b/packages/Banner/package.json
@@ -9,7 +9,7 @@
         "access": "public"
     },
     "scripts": {
-        "build": "../../shared/build-tools/build-package.js",
+        "build": "../../node_modules/.bin/rollup -c ../../shared/build-tools/rollup.config.js  ",
         "dev": "../../shared/build-tools/dev-package.js"
     },
     "license": "MIT",

--- a/packages/Button/package.json
+++ b/packages/Button/package.json
@@ -9,7 +9,7 @@
         "access": "public"
     },
     "scripts": {
-        "build": "../../shared/build-tools/build-package.js",
+        "build": "../../node_modules/.bin/rollup -c ../../shared/build-tools/rollup.config.js  ",
         "dev": "../../shared/build-tools/dev-package.js"
     },
     "license": "MIT",

--- a/packages/Calendar/package.json
+++ b/packages/Calendar/package.json
@@ -9,7 +9,7 @@
         "access": "public"
     },
     "scripts": {
-        "build": "../../shared/build-tools/build-package.js",
+        "build": "../../node_modules/.bin/rollup -c ../../shared/build-tools/rollup.config.js  ",
         "dev": "../../shared/build-tools/dev-package.js"
     },
     "license": "MIT",

--- a/packages/Card/package.json
+++ b/packages/Card/package.json
@@ -9,7 +9,7 @@
         "access": "public"
     },
     "scripts": {
-        "build": "../../shared/build-tools/build-package.js",
+        "build": "../../node_modules/.bin/rollup -c ../../shared/build-tools/rollup.config.js  ",
         "dev": "../../shared/build-tools/dev-package.js"
     },
     "license": "MIT",

--- a/packages/Checkbox/package.json
+++ b/packages/Checkbox/package.json
@@ -9,7 +9,7 @@
         "access": "public"
     },
     "scripts": {
-        "build": "../../shared/build-tools/build-package.js",
+        "build": "../../node_modules/.bin/rollup -c ../../shared/build-tools/rollup.config.js  ",
         "dev": "../../shared/build-tools/dev-package.js"
     },
     "license": "MIT",

--- a/packages/Dialog/package.json
+++ b/packages/Dialog/package.json
@@ -9,7 +9,7 @@
         "access": "public"
     },
     "scripts": {
-        "build": "../../shared/build-tools/build-package.js",
+        "build": "../../node_modules/.bin/rollup -c ../../shared/build-tools/rollup.config.js  ",
         "dev": "../../shared/build-tools/dev-package.js"
     },
     "license": "MIT",

--- a/packages/ErrorMessage/package.json
+++ b/packages/ErrorMessage/package.json
@@ -9,7 +9,7 @@
         "access": "public"
     },
     "scripts": {
-        "build": "../../shared/build-tools/build-package.js",
+        "build": "../../node_modules/.bin/rollup -c ../../shared/build-tools/rollup.config.js  ",
         "dev": "../../shared/build-tools/dev-package.js"
     },
     "license": "MIT",

--- a/packages/FileUploader/package.json
+++ b/packages/FileUploader/package.json
@@ -9,7 +9,7 @@
         "access": "public"
     },
     "scripts": {
-        "build": "../../shared/build-tools/build-package.js",
+        "build": "../../node_modules/.bin/rollup -c ../../shared/build-tools/rollup.config.js  ",
         "dev": "../../shared/build-tools/dev-package.js"
     },
     "license": "MIT",

--- a/packages/Icon/package.json
+++ b/packages/Icon/package.json
@@ -9,7 +9,7 @@
         "access": "public"
     },
     "scripts": {
-        "build": "../../shared/build-tools/build-package.js",
+        "build": "../../node_modules/.bin/rollup -c ../../shared/build-tools/rollup.config.js  ",
         "dev": "../../shared/build-tools/dev-package.js"
     },
     "license": "MIT",

--- a/packages/Input/package.json
+++ b/packages/Input/package.json
@@ -9,7 +9,7 @@
         "access": "public"
     },
     "scripts": {
-        "build": "../../shared/build-tools/build-package.js",
+        "build": "../../node_modules/.bin/rollup -c ../../shared/build-tools/rollup.config.js  ",
         "dev": "../../shared/build-tools/dev-package.js"
     },
     "license": "MIT",

--- a/packages/Label/package.json
+++ b/packages/Label/package.json
@@ -9,7 +9,7 @@
         "access": "public"
     },
     "scripts": {
-        "build": "../../shared/build-tools/build-package.js",
+        "build": "../../node_modules/.bin/rollup -c ../../shared/build-tools/rollup.config.js",
         "dev": "../../shared/build-tools/dev-package.js"
     },
     "license": "MIT",

--- a/packages/Modal/package.json
+++ b/packages/Modal/package.json
@@ -9,7 +9,7 @@
         "access": "public"
     },
     "scripts": {
-        "build": "../../shared/build-tools/build-package.js",
+        "build": "../../node_modules/.bin/rollup -c ../../shared/build-tools/rollup.config.js  ",
         "dev": "../../shared/build-tools/dev-package.js"
     },
     "license": "MIT",

--- a/packages/Radio/package.json
+++ b/packages/Radio/package.json
@@ -9,7 +9,7 @@
         "access": "public"
     },
     "scripts": {
-        "build": "../../shared/build-tools/build-package.js",
+        "build": "../../node_modules/.bin/rollup -c ../../shared/build-tools/rollup.config.js  ",
         "dev": "../../shared/build-tools/dev-package.js"
     },
     "license": "MIT",

--- a/packages/Select/package.json
+++ b/packages/Select/package.json
@@ -9,7 +9,7 @@
         "access": "public"
     },
     "scripts": {
-        "build": "../../shared/build-tools/build-package.js",
+        "build": "../../node_modules/.bin/rollup -c ../../shared/build-tools/rollup.config.js  ",
         "dev": "../../shared/build-tools/dev-package.js"
     },
     "license": "MIT",

--- a/packages/Textarea/package.json
+++ b/packages/Textarea/package.json
@@ -9,7 +9,7 @@
         "access": "public"
     },
     "scripts": {
-        "build": "../../shared/build-tools/build-package.js",
+        "build": "../../node_modules/.bin/rollup -c ../../shared/build-tools/rollup.config.js  ",
         "dev": "../../shared/build-tools/dev-package.js"
     },
     "license": "MIT",

--- a/packages/Theme/package.json
+++ b/packages/Theme/package.json
@@ -9,7 +9,7 @@
         "access": "public"
     },
     "scripts": {
-        "build": "../../shared/build-tools/build-package.js && yarn generate:scss && yarn clone:scss",
+        "build": "../../node_modules/.bin/rollup -c ../../shared/build-tools/rollup.config.js   && yarn generate:scss && yarn clone:scss",
         "dev": "../../shared/build-tools/dev-package.js",
         "generate:scss": "./src/tools/generate-scss-variables.js",
         "clone:scss": "yarn copyfiles src/**/*.scss dist --flat"

--- a/packages/Theme/package.json
+++ b/packages/Theme/package.json
@@ -11,7 +11,7 @@
     "scripts": {
         "build": "../../node_modules/.bin/rollup -c ../../shared/build-tools/rollup.config.js   && yarn generate:scss && yarn clone:scss",
         "dev": "../../shared/build-tools/dev-package.js",
-        "generate:scss": "./src/tools/generate-scss-variables.js",
+        "generate:scss": "node src/tools/generate-scss-variables.js",        
         "clone:scss": "yarn copyfiles src/**/*.scss dist --flat"
     },
     "license": "MIT",

--- a/packages/Tipsy/package.json
+++ b/packages/Tipsy/package.json
@@ -9,7 +9,7 @@
         "access": "public"
     },
     "scripts": {
-        "build": "../../shared/build-tools/build-package.js",
+        "build": "../../node_modules/.bin/rollup -c ../../shared/build-tools/rollup.config.js  ",
         "dev": "../../shared/build-tools/dev-package.js"
     },
     "license": "MIT",

--- a/packages/Toaster/package.json
+++ b/packages/Toaster/package.json
@@ -9,7 +9,7 @@
         "access": "public"
     },
     "scripts": {
-        "build": "../../shared/build-tools/build-package.js",
+        "build": "../../node_modules/.bin/rollup -c ../../shared/build-tools/rollup.config.js  ",
         "dev": "../../shared/build-tools/dev-package.js"
     },
     "license": "MIT",

--- a/packages/Toggle/package.json
+++ b/packages/Toggle/package.json
@@ -9,7 +9,7 @@
         "access": "public"
     },
     "scripts": {
-        "build": "../../shared/build-tools/build-package.js",
+        "build": "../../node_modules/.bin/rollup -c ../../shared/build-tools/rollup.config.js  ",
         "dev": "../../shared/build-tools/dev-package.js"
     },
     "license": "MIT",

--- a/packages/Typography/package.json
+++ b/packages/Typography/package.json
@@ -9,7 +9,7 @@
         "access": "public"
     },
     "scripts": {
-        "build": "../../shared/build-tools/build-package.js",
+        "build": "../../node_modules/.bin/rollup -c ../../shared/build-tools/rollup.config.js  ",
         "dev": "../../shared/build-tools/dev-package.js"
     },
     "license": "MIT",

--- a/packages/docs/README.md
+++ b/packages/docs/README.md
@@ -8,9 +8,13 @@ This creates a mapping of all components and generates a file for the components
 
 * The build starts in `gatsby-node.js` and pulls in all the documentation described above.
 
+See package.json for OS specific build commands.
+
 ## Working on the site locally
 
 To pull site data from contentful, request a access token from one of the maintainers. You will need to create a `.env` file in the root of this package and set the `CONTENTFUL_ACCESS_TOKEN` variable with the token.
+
+See package.json for OS specific build commands.
 
 ```
 CONTENTFUL_ACCESS_TOKEN={YOUR ACCESS TOKEN TO CONTENTFUL}

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -9,7 +9,7 @@
     "docs:dev": "yarn clean && yarn clone:env:file && gatsby develop",
     "docs:prod": "yarn clean && yarn clone:env:file && gatsby build",
     "docs:serve": "gatsby serve",
-    "clean": "rm -rf .cache",
+    "clean": "del -rf .cache",
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing \""
   },
   "dependencies": {

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -8,8 +8,11 @@
     "clone:env:file": "yarn copyfiles ../../.env ./docs/.env",
     "docs:dev": "yarn clean && yarn clone:env:file && gatsby develop",
     "docs:prod": "yarn clean && yarn clone:env:file && gatsby build",
+    "docs:windows:dev": "yarn clean:windows && yarn clone:env:file && gatsby develop",
+    "docs:windows:prod": "yarn clean:windows && yarn clone:env:file && gatsby build",
     "docs:serve": "gatsby serve",
-    "clean": "del -rf .cache",
+    "clean": "rm -rf .cache",
+    "clean:windows": "del -rf .cache",
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing \""
   },
   "dependencies": {


### PR DESCRIPTION
Updated commands in `package.json` files for all components to work with mac and windows OS.
Updated docs clean command to use different commands determined by what OS is being used. 
Updated the docs README to document this change.