### PR TITLE
Fix Accordion bug preventing passed in className prop from rendering …

### DIFF
--- a/packages/Accordion/src/AccordionHeader.tsx
+++ b/packages/Accordion/src/AccordionHeader.tsx
@@ -25,7 +25,7 @@ const IconChevronForward = (props: any) => (
 export type AccordionHeaderProps = AllHTMLAttributes<HTMLDivElement> & HTMLProps<HTMLDivElement>;
 
 export const AccordionHeader: FC<AccordionHeaderProps> = forwardRef((props: AccordionHeaderProps, ref) => {
-    const { children, onKeyDown, onClick = noop, ...rest } = props;
+    const { children, onKeyDown, onClick = noop, className = '', ...rest } = props;
     const { onChange, accordionId } = useContext(AccordionContext);
     const { id, isExpanded, index } = useContext(AccordionItemContext);
 
@@ -85,6 +85,7 @@ export const AccordionHeader: FC<AccordionHeaderProps> = forwardRef((props: Acco
     const headerClassNames = classnames({
         [styles.header]: true,
         [styles.headerIsOpen]: isExpanded,
+        [className]: className,
     });
     const chevronClassNames = classnames({
         [styles.chevron]: true,

--- a/packages/Accordion/src/__tests__/Accordion.test.tsx
+++ b/packages/Accordion/src/__tests__/Accordion.test.tsx
@@ -33,10 +33,10 @@ describe('Accordion', () => {
     });
     it('should render props passed through', () => {
         const { getByTestId } = render(
-            <Accordion activePanes={[0]} onChange={changeSpy} className="wrapper" data-testid="wrapper">
+            <Accordion activePanes={[0]} onChange={changeSpy} className="foo" data-testid="wrapper">
                 <AccordionItem>
                     <AccordionHeader
-                        className="header"
+                        className="bar"
                         data-randomattribute="THIS IS A TEST"
                         style={{ background: 'red' }}
                         data-testid="header"
@@ -59,12 +59,12 @@ describe('Accordion', () => {
         const header = getByTestId('header');
         const pane = getByTestId('pane');
 
-        expect(wrapper.classList.contains('wrapper')).toBe(true);
+        expect(wrapper.classList.contains('foo')).toBe(true);
 
-        expect(header.classList.contains('header')).toBe(true);
+        expect(header.classList.contains('bar')).toBe(true);
         expect(header.style.background).toBe('red');
 
-        expect(pane.classList.contains('pane')).toBe(true);
+        expect(pane.classList.contains('tester')).toBe(true);
         expect(pane.style.padding).toBe('24px');
         expect(pane.getAttribute('data-randomattribute')).toBe('THIS IS A TEST');
     });


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bug fix 

**Summary**
This PR includes a fix for a bug that was causing any passed-in `className` props to the `AccordionHeader` not to render. The `className` in the `AccordionHeader` was never actually being passed through, which is addressed, and also, the `Accordion` spec was creating a false positive for passed-in props: the specs used the same strings for `data-testid` and `className`, and it turns out the `data-testids` are included in the `classList`. 

This fix is especially needed at this exact moment in time, as the MarketingProducts team is using the Accordion to add functionality to a list of customer-facing email automations performance data.