### PR TITLE
fix: add missing mixin

### DIFF
--- a/packages/Select/src/Select.scss
+++ b/packages/Select/src/Select.scss
@@ -1,5 +1,18 @@
 @import '~@mbkit/theme/dist/theme.scss';
 
+// When using inline SVG (Checkbox component) some browsers  
+// detect encoded and display the SVG with the correct color,
+// while others do not.
+// https://gist.github.com/certainlyakey/e9c0d8f5c87ff47e3d5b
+@function encodeHexColor($string) {
+	@if type-of($string) == 'color' {
+        $hex: str-slice(ie-hex-str($string), 4);
+        $string: unquote("#{$hex}");
+    }
+    $string: '%23' + $string;
+	@return $string;
+}
+
 @mixin downChevron($fill) {
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16' class=''%3E%3Cg id='Icons/Glyphs/Chevron---Down-vfNaTDX8tnyDfRIM7JRyh' fill='none' fill-rule='evenodd' stroke='none' stroke-width='1'%3E%3Cpath id='Mask-vfNaTDX8tnyDfRIM7JRyh' fill='" + encodeHexColor($fill) + "' d='M5.6095656 3.31234752l.7808688-.62469504L10.6403124 8l-4.249878 5.3123475-.7808688-.624695L9.35968758 8z' transform='rotate(90 8.124939 8)'%3E%3C/path%3E%3C/g%3E%3C/svg%3E");
 }


### PR DESCRIPTION
Apparently, this has been broken for a while. Not sure why it hasn't really caused any problems until now. Adds missing SCSS mixin. 